### PR TITLE
Insert new cards correctly into deck

### DIFF
--- a/UPCardsCarousel/UPCardsCarousel.m
+++ b/UPCardsCarousel/UPCardsCarousel.m
@@ -235,7 +235,7 @@ const static CGFloat        kLabelsContainerHeight          = 60;
     [newCard setFrame:[oldCard frame]];
     [newCard.layer setAffineTransform:transform];
     [newCard.layer setZPosition:[oldCard.layer zPosition]];
-    [_cardsContainer insertSubview:newCard atIndex:0];
+    [_cardsContainer addSubview:newCard];
     [oldCard removeFromSuperview];
 }
 

--- a/UPCardsCarousel/UPCardsCarousel.m
+++ b/UPCardsCarousel/UPCardsCarousel.m
@@ -244,7 +244,7 @@ const static CGFloat        kLabelsContainerHeight          = 60;
 {
     NSInteger localIndex = index - _visibleCardsOffset;
     
-    if(localIndex < 0 || localIndex >= _numberOfCards)
+    if(localIndex < 0 || localIndex >= [_visibleCards count])
         return nil;
     
     return [_visibleCards objectAtIndex:localIndex];

--- a/UPCardsCarousel/UPCardsCarousel.m
+++ b/UPCardsCarousel/UPCardsCarousel.m
@@ -189,7 +189,7 @@ const static CGFloat        kLabelsContainerHeight          = 60;
         NSInteger zIndex = visible ? _visibleDeckZPositionOffset+(cardsCount-1-offset) : _hiddenDeckZPositionOffset+offset;
         [card.layer setZPosition:zIndex];
         
-        [_cardsContainer addSubview:card];
+        [_cardsContainer insertSubview:card atIndex:0];
         
         [_visibleCards addObject:card];
     }
@@ -235,7 +235,7 @@ const static CGFloat        kLabelsContainerHeight          = 60;
     [newCard setFrame:[oldCard frame]];
     [newCard.layer setAffineTransform:transform];
     [newCard.layer setZPosition:[oldCard.layer zPosition]];
-    [_cardsContainer addSubview:newCard];
+    [_cardsContainer insertSubview:newCard atIndex:0];
     [oldCard removeFromSuperview];
 }
 
@@ -320,7 +320,7 @@ const static CGFloat        kLabelsContainerHeight          = 60;
         [self positionCard:newCard toVisible:(wayValue == 1)];
         [newCard.layer setZPosition:newCardZPosition];
         [newCard setAlpha:0.0f];
-        [_cardsContainer addSubview:newCard];
+        [_cardsContainer insertSubview:newCard atIndex:0];
         
         for(int i = 0; i < [_visibleCards count]; i++) {
             // Don't recompute the moving card z-index, it will be set at the end of the animation


### PR DESCRIPTION
Insert new cards at index 0, instead of using addSubview

Correct order:
![screen shot 2015-01-09 at 1 46 06 am](https://cloud.githubusercontent.com/assets/4203943/5676299/975dd9f8-97a1-11e4-9609-be8c85aba53a.png)

Contrast this with incorrect order from https://github.com/ink-spot/UPCardsCarousel/issues/3
![screen shot 2015-01-09 at 1 17 39 am](https://cloud.githubusercontent.com/assets/4203943/5676293/7830b7da-97a1-11e4-8ecd-b50499eb6a30.png)

